### PR TITLE
Add tag using stream

### DIFF
--- a/src/main/java/lumi/Parser.java
+++ b/src/main/java/lumi/Parser.java
@@ -60,6 +60,19 @@ public class Parser {
                 throw new LumiException("OOPS!!! Please specify a task number to mark.");
             }
             return new MarkCommand(Integer.parseInt(words[1].trim()) - 1);
+        case "tag":
+            String[] tagParts = words[1].split("#", 2);
+            if (tagParts.length < 2 || !tagParts[1].startsWith("#")) {
+                throw new LumiException("tag 4 #fun).");
+            }
+
+            try {
+                int taskNumber = Integer.parseInt(tagParts[0]) - 1;
+                String tag = tagParts[1].substring(1).trim(); // Remove '#' before storing
+                return new TagCommand(taskNumber, tag);
+            } catch (NumberFormatException e) {
+                throw new LumiException("OOPS!!! Task number must be a valid number.");
+            }
         case"hi":
             return new WelcomeCommand();
         default: throw new LumiException("OOPS!!! I'm sorry, but I don't understand that command.");

--- a/src/main/java/lumi/Storage.java
+++ b/src/main/java/lumi/Storage.java
@@ -91,11 +91,12 @@ public class Storage {
                 : task instanceof Deadline ? "D"
                         : task instanceof Event ? "E" : "?";
         String status = task.isDone ? "1" : "0";
+        String tag = task.getTag().isEmpty() ? "" : " | #" + task.getTag();
 
         if (task instanceof Deadline) {
-            return type + " | " + status + " | " + task.description + " | " + ((Deadline) task).by.toString();
+            return type + " | " + status + " | " + task.description + " | " + ((Deadline) task).by.toString() + tag;
         } else {
-            return type + " | " + status + " | " + task.description;
+            return type + " | " + status + " | " + task.description + tag;
         }
     }
 
@@ -128,6 +129,11 @@ public class Storage {
 
         if (task != null && isDone) {
             task.markAsDone();
+        }
+
+        // Load tag if present
+        if (parts.length >= 6 && parts[5].startsWith("#")) {
+            task.setTag(parts[5].substring(1)); // Remove '#' before storing
         }
 
         return task;

--- a/src/main/java/lumi/TagCommand.java
+++ b/src/main/java/lumi/TagCommand.java
@@ -1,0 +1,37 @@
+package lumi;
+
+/**
+ * Creates an TagCommand to tag the specified task.
+ */
+public class TagCommand extends Command {
+    private final int taskIndex;
+    private final String tag;
+
+    /**
+     * Constructor of TagCommand
+     * @param taskIndex
+     * @param tag
+     */
+    public TagCommand(int taskIndex, String tag) {
+        this.taskIndex = taskIndex;
+        this.tag = tag;
+    }
+    /**
+     * Executes the  TagCommand by set tag to the task from the task list
+     * @param tasks The task list to delete the task from.
+     * @param ui The UI instance for displaying messages.
+     * @param storage The storage instance to save tasks.
+     * @throws LumiException If an error occurs while deleting the task.
+     */
+    @Override
+    public void execute(TaskList tasks, Ui ui, Storage storage) throws LumiException {
+        if (taskIndex < 0 || taskIndex >= tasks.size()) {
+            throw new LumiException("OOPS!!! Invalid task number.");
+        }
+
+        Task task = tasks.get(taskIndex);
+        task.setTag(tag);
+        storage.saveTasks(tasks.getTasks());
+        ui.showMessage("Tagged task: " + task);
+    }
+}

--- a/src/main/java/lumi/Task.java
+++ b/src/main/java/lumi/Task.java
@@ -2,12 +2,15 @@
 
 package lumi;
 
+import java.util.Optional;
+
 /**
  * Represents a task with a description and completion status.
  */
 public class Task {
     protected String description;
     protected boolean isDone;
+    protected Optional<String> tag = Optional.empty();
 
     /**
      * Creates a new task with the given description.
@@ -53,11 +56,29 @@ public class Task {
     }
 
     /**
+     * Tag an description
+     * @param tag
+     */
+    public void setTag(String tag) {
+        this.tag = Optional.of(tag);
+    }
+
+    /**
+     * Get the tag
+     * return empty is user did not set tag
+     * @return
+     */
+    public String getTag() {
+        return tag.orElse("");
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public String toString() {
-        return "[" + getStatusIcon() + "] " + description;
+        String tagString = tag.map(t -> " #" + t).orElse("");
+        return "[" + getStatusIcon() + "] " + description + tagString;
     }
 }
 


### PR DESCRIPTION
Previously, tasks could not be categorized or labeled, making it difficult to organize them based on
user-defined themes or priorities.

Introduce a `tag` command that allows users to
add tags to tasks.
to persist tags when saving and loading tasks.
Update `Parser` to handle the
new `tag` command and validate input.

Using `Optional<String>` for tags ensures
that tasks without tags remain clean.
The new feature improves task organization without affecting existing functionality.